### PR TITLE
Meta tweaks and doc improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,*.yml}]
+[*.yml]
 indent_style = space
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.js text eol=lf

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+  - '10'
+  - '8'
   - '6'
   - '4'

--- a/license
+++ b/license
@@ -1,21 +1,9 @@
-The MIT License (MIT)
+MIT License
 
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,40 +1,37 @@
 {
-  "name": "callsites",
-  "version": "2.0.0",
-  "description": "Get callsites from the V8 stack trace API",
-  "license": "MIT",
-  "repository": "sindresorhus/callsites",
-  "author": {
-    "name": "Sindre Sorhus",
-    "email": "sindresorhus@gmail.com",
-    "url": "sindresorhus.com"
-  },
-  "engines": {
-    "node": ">=4"
-  },
-  "scripts": {
-    "test": "xo && ava"
-  },
-  "files": [
-    "index.js"
-  ],
-  "keywords": [
-    "stacktrace",
-    "v8",
-    "callsite",
-    "callsites",
-    "stack",
-    "trace",
-    "function",
-    "file",
-    "line",
-    "debug"
-  ],
-  "devDependencies": {
-    "ava": "*",
-    "xo": "*"
-  },
-  "xo": {
-    "esnext": true
-  }
+	"name": "callsites",
+	"version": "2.0.0",
+	"description": "Get callsites from the V8 stack trace API",
+	"license": "MIT",
+	"repository": "sindresorhus/callsites",
+	"author": {
+		"name": "Sindre Sorhus",
+		"email": "sindresorhus@gmail.com",
+		"url": "sindresorhus.com"
+	},
+	"engines": {
+		"node": ">=4"
+	},
+	"scripts": {
+		"test": "xo && ava"
+	},
+	"files": [
+		"index.js"
+	],
+	"keywords": [
+		"stacktrace",
+		"v8",
+		"callsite",
+		"callsites",
+		"stack",
+		"trace",
+		"function",
+		"file",
+		"line",
+		"debug"
+	],
+	"devDependencies": {
+		"ava": "^0.25.0",
+		"xo": "^0.23.0"
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # callsites [![Build Status](https://travis-ci.org/sindresorhus/callsites.svg?branch=master)](https://travis-ci.org/sindresorhus/callsites)
 
-> Get callsites from the [V8 stack trace API](https://github.com/v8/v8/wiki/Stack-Trace-API)
+> Get callsites from the [V8 stack trace API](https://v8.dev/docs/stack-trace-api)
 
 
 ## Install
@@ -28,17 +28,22 @@ unicorn();
 
 Returns an array of callsite objects with the following methods:
 
-- `getTypeName`: returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
-- `getFunctionName`: returns the name of the current function, typically its name property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
-- `getMethodName`: returns the name of the property of this or one of its prototypes that holds the current function
-- `getFileName`: if this function was defined in a script returns the name of the script
-- `getLineNumber`: if this function was defined in a script returns the current line number
+- `getThis`: returns the value of `this`.
+- `getTypeName`: returns the type of `this` as a string. This is the name of the function stored in the constructor field of `this`, if available, otherwise the object's `[[Class]]` internal property.
+- `getFunction`: returns the current function.
+- `getFunctionName`: returns the name of the current function, typically its `name` property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
+- `getMethodName`: returns the name of the property of `this` or one of its prototypes that holds the current function.
+- `getFileName`: if this function was defined in a script returns the name of the script.
+- `getLineNumber`: if this function was defined in a script returns the current line number.
 - `getColumnNumber`: if this function was defined in a script returns the current column number
-- `getEvalOrigin`: if this function was created using a call to eval returns a CallSite object representing the location where eval was called
+- `getEvalOrigin`: if this function was created using a call to `eval` returns a string representing the location where `eval` was called.
 - `isToplevel`: is this a top-level invocation, that is, is this the global object?
-- `isEval`: does this call take place in code defined by a call to eval?
+- `isEval`: does this call take place in code defined by a call to `eval`?
 - `isNative`: is this call in native V8 code?
 - `isConstructor`: is this a constructor call?
+- `isAsync`: is this an async call (i.e. `await` or `Promise.all()`)?
+- `isPromiseAll`: is this an async call to `Promise.all()`?
+- `getPromiseIndex`: returns the index of the promise element that was followed in `Promise.all()` for async stack traces, or `null` if the `CallSite` is not a `Promise.all()` call.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test(t => {
 	t.is(path.basename(m()[0].getFileName()), 'test.js');


### PR DESCRIPTION
I wanted to add TypeScript definitions but noticed from the [V8 Stack Trace API docs](https://v8.dev/docs/stack-trace-api) that some methods where missing from the docs here.

Also needed a fresh lick of paint in some other files :).

After this one is merged, I'll do another PR to add the TypeScript definitions.