### PR TITLE
Add support for Bun as well as existing runtimes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export default function callsites() {
 		let result = [];
 		Error.prepareStackTrace = (_, callSites) => {
 			const callSitesWithoutCurrent = callSites.slice(1);
-			result = callSitesWithoutCurrent
+			result = callSitesWithoutCurrent;
 			return callSitesWithoutCurrent;
 		};
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,16 @@
 export default function callsites() {
 	const _prepareStackTrace = Error.prepareStackTrace;
-	Error.prepareStackTrace = (_, stack) => stack;
-	const stack = new Error().stack.slice(1); // eslint-disable-line unicorn/error-message
-	Error.prepareStackTrace = _prepareStackTrace;
-	return stack;
+	try {
+		const result = [];
+		Error.prepareStackTrace = (_, callSites) => {
+			const callSitesWithoutCurrent = callSites.slice(1);
+			result.push(...callSitesWithoutCurrent);
+			return callSitesWithoutCurrent;
+		};
+
+		new Error().stack; // eslint-disable-line unicorn/error-message,no-unused-expressions
+		return result;
+	} finally {
+		Error.prepareStackTrace = _prepareStackTrace;
+	}
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ export default function callsites() {
 			return callSitesWithoutCurrent;
 		};
 
-		new Error().stack; // eslint-disable-line unicorn/error-message,no-unused-expressions
+		new Error().stack; // eslint-disable-line unicorn/error-message, no-unused-expressions
 		return result;
 	} finally {
 		Error.prepareStackTrace = _prepareStackTrace;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 export default function callsites() {
 	const _prepareStackTrace = Error.prepareStackTrace;
 	try {
-		const result = [];
+		let result = [];
 		Error.prepareStackTrace = (_, callSites) => {
 			const callSitesWithoutCurrent = callSites.slice(1);
-			result.push(...callSitesWithoutCurrent);
+			result = callSitesWithoutCurrent
 			return callSitesWithoutCurrent;
 		};
 


### PR DESCRIPTION
In Bun, `new Error().stack` currently returns a string rather than the mutation from `prepareStackTrace`. This fix avoids this issue by storing the callstack in a variable rather than mutating the return type. This possibly helps with async issues using this code too.