### PR TITLE
Add methods for async stack traces with Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,7 @@ export interface CallSite {
 	isConstructor(): boolean;
 
 	/**
-	Returns `true` if this call is asynchronous.
+	Returns `true` if this call is asynchronous (i.e. `await`, `Promise.all()`, or `Promise.any()`).
 	*/
 	isAsync(): boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ export interface CallSite {
 	isPromiseAll(): boolean;
 
 	/**
-	Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the CallSite is not an asynchronous Promise.all() or Promise.any() call.
+	Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the CallSite is not an asynchronous `Promise.all()` or `Promise.any()` call.
 	*/
 	getPromiseIndex(): number | null;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ export interface CallSite {
 	isPromiseAll(): boolean;
 
 	/**
-	Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the CallSite is not an asynchronous `Promise.all()` or `Promise.any()` call.
+	Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the `CallSite` is not an asynchronous `Promise.all()` or `Promise.any()` call.
 	*/
 	getPromiseIndex(): number | null;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,21 @@ export interface CallSite {
 	Returns `true` if this is a constructor call.
 	*/
 	isConstructor(): boolean;
+
+	/**
+	Returns `true` if this call is asynchronous.
+	*/
+	isAsync(): boolean;
+
+	/**
+	Returns `true` if this is an asynchronous call to `Promise.all()`.
+	*/
+	isPromiseAll(): boolean;
+
+	/**
+	Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the CallSite is not an asynchronous Promise.all() or Promise.any() call.
+	*/
+	getPromiseIndex(): number | null;
 }
 
 /**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,3 +16,6 @@ expectType<boolean>(callsite.isToplevel());
 expectType<boolean>(callsite.isEval());
 expectType<boolean>(callsite.isNative());
 expectType<boolean>(callsite.isConstructor());
+expectType<boolean>(callsite.isAsync());
+expectType<boolean>(callsite.isPromiseAll());
+expectType<number | null>(callsite.getPromiseIndex());

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Returns an array of callsite objects with the following methods:
 - `isConstructor`: Is this a constructor call?
 - `isAsync()`: 	Returns `true` if this call is asynchronous (i.e. `await`, `Promise.all()`, or `Promise.any()`).
 - `isPromiseAll()`: Returns `true` if this is an asynchronous call to `Promise.all()`.
-- `getPromiseIndex()`: Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the CallSite is not an asynchronous `Promise.all()` or `Promise.any()` call.
+- `getPromiseIndex()`: Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the `CallSite` is not an asynchronous `Promise.all()` or `Promise.any()` call.
 	
 	
 ---

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,11 @@ Returns an array of callsite objects with the following methods:
 - `isEval`: Does this call take place in code defined by a call to `eval`?
 - `isNative`: Is this call in native V8 code?
 - `isConstructor`: Is this a constructor call?
-
+- `isAsync()`: Is this an asynchronous call (i.e. await, Promise.all(), or Promise.any())?
+- `isPromiseAll()`: Is this an asynchronous call to `Promise.all()`?
+- `getPromiseIndex()`: Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the CallSite is not an asynchronous `Promise.all()` or `Promise.any()` call.
+	
+	
 ---
 
 <div align="center">

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Returns an array of callsite objects with the following methods:
 - `isEval`: Does this call take place in code defined by a call to `eval`?
 - `isNative`: Is this call in native V8 code?
 - `isConstructor`: Is this a constructor call?
-- `isAsync()`: Is this an asynchronous call (i.e. await, Promise.all(), or Promise.any())?
+- `isAsync()`: Is this an asynchronous call (i.e. `await`, `Promise.all()`, or `Promise.any()`)?
 - `isPromiseAll()`: Is this an asynchronous call to `Promise.all()`?
 - `getPromiseIndex()`: Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the CallSite is not an asynchronous `Promise.all()` or `Promise.any()` call.
 	

--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,8 @@ Returns an array of callsite objects with the following methods:
 - `isEval`: Does this call take place in code defined by a call to `eval`?
 - `isNative`: Is this call in native V8 code?
 - `isConstructor`: Is this a constructor call?
-- `isAsync()`: Is this an asynchronous call (i.e. `await`, `Promise.all()`, or `Promise.any()`)?
-- `isPromiseAll()`: Is this an asynchronous call to `Promise.all()`?
+- `isAsync()`: 	Returns `true` if this call is asynchronous (i.e. `await`, `Promise.all()`, or `Promise.any()`).
+- `isPromiseAll()`: Returns `true` if this is an asynchronous call to `Promise.all()`.
 - `getPromiseIndex()`: Returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the CallSite is not an asynchronous `Promise.all()` or `Promise.any()` call.
 	
 	


### PR DESCRIPTION
## Changes

I've added the methods for async stack traces alongside the Typescript definitions. V8 has supported this feature by default since [v7.3](https://v8.dev/blog/v8-release-73#async-stack-traces). The official definitions and descriptions can be found [here](https://v8.dev/docs/stack-trace-api#customizing-stack-traces).

## Test

- [x] `npm test` passes - both source code and type definitions test 